### PR TITLE
Add "Other" section to front page

### DIFF
--- a/site/web/index.php
+++ b/site/web/index.php
@@ -118,31 +118,33 @@ render_header();
     <h4>&nbsp;</h4>
     <p>Find out the latest news and other information about <?php echo CON_NAME; ?>.</p>
   </a>
+</div>
 
 <?php
-  if (current_user_has_permission('manage-roles')) {
+$has_manage_roles = current_user_has_permission('manage-roles');
+$has_manage_discord = current_user_has_permission('manage-discord-ids');
+$has_other = $has_manage_roles || $has_manage_discord;
+if ($has_other) {
 ?>
-  <a href="/admin/roles" class="card manage-roles">
-    <div class="hero"></div>
-    <h3>Manage roles</h3>
-    <h4>Admin area</h4>
-    <p>Create roles and set what permissions those roles have.</p>
-  </a>
+<div class="other">
+  <h2>Other</h2>
+  <ul>
+<?php
+  if ($has_manage_roles) {
+?>
+    <li><a href="/admin/roles">Manage roles</a></li>
 <?php
   }
 ?>
-
 <?php
-  if (current_user_has_permission('manage-discord-ids')) {
+  if ($has_manage_discord) {
 ?>
-  <a href="/admin/discord" class="card discord-mod">
-    <div class="hero"></div>
-    <h3>Discord ids</h3>
-    <h4>Admin area</h4>
-    <p>See what member's discord ids are.</p>
-  </a>
+    <li><a href="/admin/discord">Discord ids</a></li>
 <?php
   }
+?>
+<?php
+}
 ?>
 
 </div>

--- a/site/web/resources/style.css
+++ b/site/web/resources/style.css
@@ -227,6 +227,19 @@ main {
   font-size: 18px;
 }
 
+.other {
+  margin-top: 1rem;
+}
+
+.other h2 {
+  font-size: 1.5rem;
+  line-height: 1.5;
+}
+
+.other li {
+  font-size: 1.2rem;
+}
+
 article {
   line-height: 1.5;
   margin-top: 1em;


### PR DESCRIPTION
Some things don't need the full space of a card, so add an "Other" section at the bottom. This gives us a space to put stuff that needs to be on the portal, but isn't important enough to need a card and all that comes with it (extra real-estate taken up, having to find card art, etc.)

![image](https://github.com/glasgow2024/member-portal/assets/615131/75eb7def-6257-4bd2-8ac5-8c99c667339f)
