### PR TITLE
Add convention time card

### DIFF
--- a/site/web/index.php
+++ b/site/web/index.php
@@ -7,6 +7,13 @@ render_header();
 ?>
 
 <div class="cards">
+  <a href="https://dateful.com/convert/british-summer-time-bst" class="card time">
+    <div class="hero" id="time"></div>
+    <h3>Current convention time</h3>
+    <h4>BST</h4>
+    <p>Convert between convention time (BST) and your local timezone.</p>
+  </a>
+
 <?php
   if (current_user_has_permission('see-readme')) {
 ?>
@@ -148,6 +155,16 @@ if ($has_other) {
 ?>
 
 </div>
+
+<script>
+  let $time = document.getElementById('time');
+  function updateTime() {
+    let utc = new Date();
+    $time.innerText = utc.toLocaleString('en-GB', { timeZone: 'Europe/London', hour: 'numeric', minute: 'numeric', hour12: false });
+    setTimeout(updateTime, 10000);
+  }
+  updateTime();
+</script>
 
 <?php
 render_footer();

--- a/site/web/resources/style.css
+++ b/site/web/resources/style.css
@@ -172,6 +172,15 @@ main {
   background-size: cover;
 }
 
+.card.time .hero {
+  font-size: 4em;
+  color: #444;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: #EEE;
+}
+
 .card.readme .hero {
   background-image: url('/resources/readme.jpg');
 }


### PR DESCRIPTION
This shows the current time in the convention timezone (BST) and provides a link to a site to convert between BST and their local timezone.

The card's hero is a clock that automatically updates (with a 10 second resolution).

![image](https://github.com/glasgow2024/member-portal/assets/615131/d61e5d58-c098-41d3-80cf-ecb0752a7818)
