### PR TITLE
Auto-detect the root url

### DIFF
--- a/site/lib/clyde_service.php
+++ b/site/lib/clyde_service.php
@@ -8,9 +8,8 @@ class ClydeService {
   public $token;
 
   function __construct() {
-    $host = $_SERVER['HTTP_X_FORWARDED_HOST'] ?? _SERVER['HTTP_X_FORWARDED_HOST'];
     $this->provider = new \League\OAuth2\Client\Provider\GenericProvider([
-      'redirectUri'             => 'https://' . $host . '/clyde_callback',
+      'redirectUri'             => ROOT_URL . '/clyde_callback',
       'clientId'                => CLYDE_CLIENT_ID,
       'clientSecret'            => CLYDE_CLIENT_SECRET,
       'urlAuthorize'            => CLYDE_SERVER_ENDPOINT . '/oauth/authorize',

--- a/site/lib/config.php
+++ b/site/lib/config.php
@@ -1,6 +1,6 @@
 <?php
 
-define('ROOT_URL', 'http://portal.glasgow2024.org/');
+define('ROOT_URL', 'https://' . $_SERVER['HTTP_X_FORWARDED_HOST'] ?? _SERVER['HTTP_HOST']);
 define('CON_NAME', 'Glasgow 2024, a Worldcon for Our Futures');
 define('CON_SHORT_NAME', 'Glasgow 2024');
 define('DISCORD_CHANNEL_ID', '1214240728184787013');


### PR DESCRIPTION
We're all going to have different root urls in our development environment (because we need a public URL to redirect back to for Clyde). Rather than having everyone fight over the config file, auto-detect it.