### PR TITLE
Use 404 error if missing permissions

### DIFF
--- a/site/lib/session_auth.php
+++ b/site/lib/session_auth.php
@@ -2,6 +2,13 @@
 require_once('auth_functions.php');
 require_once('db.php');
 
+function check_permission($permission) {
+  if (!current_user_has_permission($permission)) {
+    require_once('template.php');
+    render_404();
+  }
+}
+
 if (!is_logged_in()) {
   header('Location: /login');
   exit;

--- a/site/lib/template.php
+++ b/site/lib/template.php
@@ -1,5 +1,6 @@
 <?php
   require_once('config.php');
+  require_once('auth_functions.php');
 
   function get_internal_url($script) {
     return $script . '?v=' . hash_file('md5', getenv('CONFIG_WEB_DIR') . $script);
@@ -63,5 +64,19 @@
   </body>
 </html>
 <?php
+  }
+
+  function render_404() {
+    http_response_code(404);
+    render_header();
+?>
+    <a href="/" class="back">&lt; Back to member portal</a>
+    <article>
+      <h3>Page not found</h3>
+      <p>The page you are looking for does not exist.</p>
+    </article>
+<?php
+    render_footer();
+    exit;
   }
 ?>

--- a/site/web/.htaccess
+++ b/site/web/.htaccess
@@ -1,3 +1,5 @@
+ErrorDocument 404 /404.php
+
 <IfModule mod_rewrite.c>
   RewriteEngine On
   RewriteBase /

--- a/site/web/404.php
+++ b/site/web/404.php
@@ -1,0 +1,4 @@
+<?php
+require_once(getenv('CONFIG_LIB_DIR') . '/template.php');
+render_404();
+?>

--- a/site/web/admin/discord.php
+++ b/site/web/admin/discord.php
@@ -3,10 +3,7 @@ require_once(getenv('CONFIG_LIB_DIR') . '/config.php');
 require_once(getenv('CONFIG_LIB_DIR') . '/session_auth.php');
 require_once(getenv('CONFIG_LIB_DIR') . '/template.php');
 
-if (!current_user_has_permission('manage-discord-ids')) {
-  header('Location: /');
-  exit;
-}
+check_permission('manage-discord-ids');
 
 render_header();
 ?>

--- a/site/web/admin/roles.php
+++ b/site/web/admin/roles.php
@@ -4,10 +4,7 @@ require_once(getenv('CONFIG_LIB_DIR') . '/session_auth.php');
 require_once(getenv('CONFIG_LIB_DIR') . '/db.php');
 require_once(getenv('CONFIG_LIB_DIR') . '/template.php');
 
-if (!current_user_has_permission('manage-roles')) {
-  header('Location: /');
-  exit;
-}
+check_permission('manage-roles');
 
 function render_form_body($role_id = 1) {
 ?>

--- a/site/web/newsletter.php
+++ b/site/web/newsletter.php
@@ -3,10 +3,7 @@ require_once(getenv('CONFIG_LIB_DIR') . '/config.php');
 require_once(getenv('CONFIG_LIB_DIR') . '/session_auth.php');
 require_once(getenv('CONFIG_LIB_DIR') . '/template.php');
 
-if (!current_user_has_permission('see-newsletter')) {
-  header('Location: /');
-  exit;
-}
+check_permission('see-newsletter');
 
 render_header();
 ?>

--- a/site/web/participants.php
+++ b/site/web/participants.php
@@ -3,10 +3,7 @@ require_once(getenv('CONFIG_LIB_DIR') . '/config.php');
 require_once(getenv('CONFIG_LIB_DIR') . '/session_auth.php');
 require_once(getenv('CONFIG_LIB_DIR') . '/template.php');
 
-if (!current_user_has_permission('see-participant-guides')) {
-  header('Location: /');
-  exit;
-}
+check_permission('see-participant-guides');
 
 $magic_link = db_get_magic_link($_COOKIE['session']);
 

--- a/site/web/souvenir.php
+++ b/site/web/souvenir.php
@@ -3,10 +3,7 @@ require_once(getenv('CONFIG_LIB_DIR') . '/config.php');
 require_once(getenv('CONFIG_LIB_DIR') . '/session_auth.php');
 require_once(getenv('CONFIG_LIB_DIR') . '/template.php');
 
-if (!current_user_has_permission('see-souvenir')) {
-  header('Location: /');
-  exit;
-}
+check_permission('see-sovenir');
 
 $magic_link = db_get_magic_link($_COOKIE['session']);
 

--- a/site/web/vote.php
+++ b/site/web/vote.php
@@ -3,10 +3,7 @@ require_once(getenv('CONFIG_LIB_DIR') . '/config.php');
 require_once(getenv('CONFIG_LIB_DIR') . '/session_auth.php');
 require_once(getenv('CONFIG_LIB_DIR') . '/template.php');
 
-if (!current_user_has_permission('see-vote')) {
-  header('Location: /');
-  exit;
-}
+check_permission('see-vote');
 
 $doc_vote_open = strtotime('2024-03-29 12:00');
 $doc_vote_close = strtotime('2024-04-01 11:00');


### PR DESCRIPTION
Previously we were redirecting to `/`, which served the function of stopping them accessing the page, but was neither an informative error nor secure (it lets people know what resources exist).

Instead, add a custom 404 page and render that if they are missing permissions.

![image](https://github.com/glasgow2024/member-portal/assets/615131/f425e42a-7ab3-4ab2-88ca-68350f3db030)
