### PR TITLE
Fix login bug calling non-existant function

### DIFF
--- a/site/lib/clyde_service.php
+++ b/site/lib/clyde_service.php
@@ -52,33 +52,33 @@ class ClydeService {
   }
 
   function registrant_allowed_access($registrant) {
-    if ($registrant['attending_status'] != 'Not Attending') {
-      // Check as to whether the registrant is really attending ...
-      // which means looking at the 'product_list_name' as well.
-      // Exceptions are: 
-      // Teen Attending, Child Attending, Infant Attending, Apocryphal
-      // Under 16 Day Tickets
-
-      $under_age = in_array(
-        $registrant['product_list_name'], 
-        [
-          "Teenager", "Children", "Infant",
-          "Thu. <16", "Fri. <16", "Sat. <16", "Sun. <16", "Mon. <16", "WkEnd <16"
-        ]
-      );
-
-      if ($under_age) {
-        return 1;
-      };
-
-      if ($registrant['product_list_name'] == "Apocryphal") {
-        return 2;
-      }
-
-      return 0;
-    } else {
-      return 3;
+    if ($registrant['attending_status'] == 'Not Attending') {
+      return "no-access";
     }
+
+    // Check as to whether the registrant is really attending ...
+    // which means looking at the 'product_list_name' as well.
+    // Exceptions are:
+    // Teen Attending, Child Attending, Infant Attending, Apocryphal
+    // Under 16 Day Tickets
+
+    $under_age = in_array(
+      $registrant['product_list_name'],
+      [
+        "Teenager", "Children", "Infant",
+        "Thu. <16", "Fri. <16", "Sat. <16", "Sun. <16", "Mon. <16", "WkEnd <16"
+      ]
+    );
+
+    if ($under_age) {
+      return "under-age";
+    };
+
+    if ($registrant['product_list_name'] == "Apocryphal") {
+      return "apocryphal";
+    }
+
+    return null;
   }
 }
 

--- a/site/web/clyde_callback.php
+++ b/site/web/clyde_callback.php
@@ -29,19 +29,9 @@ try {
 $registrant = $clyde->get_registrant();
 
 // 3. Check allowed access
-$access_code = registrant_allowed_access($registrant);
-if ($access_code > 0) {
-  switch ($access_code) {
-    case 1:
-      redirect_to_error('under-age');
-      break;
-    case 2:
-      redirect_to_error('apocraphyl');
-      break;
-    default:
-      redirect_to_error('no-access');
-      break;
-  }
+$access_code = $clyde->registrant_allowed_access($registrant);
+if ($access_code != null) {
+  redirect_to_error($access_code);
 }
 
 // and if acccess is alllowed create a session etc


### PR DESCRIPTION
We were calling `registrant_allowed_access` when we should have been calling `$clyde->registrant_allowed_access`.