### PR TITLE
Add /api/verify-discord-id endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,8 +102,13 @@ secrets:
     # ; This comes from the Discord Developer Portal.
     # client_secret =
     #
+    # ; The shared secrets to use for the apis. The keys are the name of the
+    # ; client, and the value is the shared secret. This should be a random
+    # ; string.
+    # [api_keys]
+    #
     # [rce]
-    # 
+    #
     # ; The API key for the RingCentral Events API.
     # ; This comes from RingCentral.
     # api_key =
@@ -111,7 +116,7 @@ secrets:
     # ; The id of the ticket to generate magic links for.
     # ; This comes from the RingCentral event config.
     # ticket_id =
-    # 
+    #
     # [clyde]
     # ; The if of the clyde client
     # client_id =
@@ -122,7 +127,7 @@ secrets:
     # ; List of emails that are allowed to log into the portal.
     # ; If not specified, then anyone can log in.
     # allowlist[] =
-    # 
+    #
     file: ./secrets/web_secrets.ini
 
 networks:

--- a/site/lib/config.php
+++ b/site/lib/config.php
@@ -3,7 +3,8 @@
 define('ROOT_URL', 'https://' . $_SERVER['HTTP_X_FORWARDED_HOST'] ?? _SERVER['HTTP_HOST']);
 define('CON_NAME', 'Glasgow 2024, a Worldcon for Our Futures');
 define('CON_SHORT_NAME', 'Glasgow 2024');
-define('DISCORD_CHANNEL_ID', '1214240728184787013');
+define('DISCORD_INVITE_CHANNEL_ID', '1214240728184787013');
+define('DISCORD_API_CHANNEL_ID', '1248917066807775232');
 define("EMAIL", "info@eastercon2024.co.uk");
 define('TIMEZONE', 'Europe/London');
 
@@ -18,6 +19,7 @@ define('RCE_TICKET_ID', $config_file['rce']['ticket_id']);
 define('DISCORD_BOT_TOKEN', $config_file['discord']['bot_token']);
 define('DISCORD_CLIENT_ID', $config_file['discord']['client_id']);
 define('DISCORD_CLIENT_SECRET', $config_file['discord']['client_secret']);
+define('API_KEYS', $config_file['api_keys']);
 
 define('CLYDE_CLIENT_ID', $config_file['clyde']['client_id']);
 define('CLYDE_CLIENT_SECRET', $config_file['clyde']['client_secret']);

--- a/site/php-migrations/composer.lock
+++ b/site/php-migrations/composer.lock
@@ -546,16 +546,16 @@
         },
         {
             "name": "robmorgan/phinx",
-            "version": "0.16.0",
+            "version": "0.16.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/phinx.git",
-                "reference": "e039a723e9fe33e406102ac1c3dc0a54c031152f"
+                "reference": "6e522d638413bb20e42b17a65508784201bbc83e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/phinx/zipball/e039a723e9fe33e406102ac1c3dc0a54c031152f",
-                "reference": "e039a723e9fe33e406102ac1c3dc0a54c031152f",
+                "url": "https://api.github.com/repos/cakephp/phinx/zipball/6e522d638413bb20e42b17a65508784201bbc83e",
+                "reference": "6e522d638413bb20e42b17a65508784201bbc83e",
                 "shasum": ""
             },
             "require": {
@@ -626,22 +626,22 @@
             ],
             "support": {
                 "issues": "https://github.com/cakephp/phinx/issues",
-                "source": "https://github.com/cakephp/phinx/tree/0.16.0"
+                "source": "https://github.com/cakephp/phinx/tree/0.16.1"
             },
-            "time": "2024-01-24T05:06:44+00:00"
+            "time": "2024-06-03T14:23:41+00:00"
         },
         {
             "name": "symfony/config",
-            "version": "v7.1.0",
+            "version": "v7.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "c4a60be1c7ec93aa8b7f19e07b6427143a502ef4"
+                "reference": "2210fc99fa42a259eb6c89d1f724ce0c4d62d5d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/c4a60be1c7ec93aa8b7f19e07b6427143a502ef4",
-                "reference": "c4a60be1c7ec93aa8b7f19e07b6427143a502ef4",
+                "url": "https://api.github.com/repos/symfony/config/zipball/2210fc99fa42a259eb6c89d1f724ce0c4d62d5d2",
+                "reference": "2210fc99fa42a259eb6c89d1f724ce0c4d62d5d2",
                 "shasum": ""
             },
             "require": {
@@ -687,7 +687,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v7.1.0"
+                "source": "https://github.com/symfony/config/tree/v7.1.1"
             },
             "funding": [
                 {
@@ -703,20 +703,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-28T06:54:05+00:00"
+            "time": "2024-05-31T14:57:53+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v7.1.0",
+            "version": "v7.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "5bcde9e0b2ea9bd9772bca17618365ea921c5707"
+                "reference": "9b008f2d7b21c74ef4d0c3de6077a642bc55ece3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/5bcde9e0b2ea9bd9772bca17618365ea921c5707",
-                "reference": "5bcde9e0b2ea9bd9772bca17618365ea921c5707",
+                "url": "https://api.github.com/repos/symfony/console/zipball/9b008f2d7b21c74ef4d0c3de6077a642bc55ece3",
+                "reference": "9b008f2d7b21c74ef4d0c3de6077a642bc55ece3",
                 "shasum": ""
             },
             "require": {
@@ -780,7 +780,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.1.0"
+                "source": "https://github.com/symfony/console/tree/v7.1.1"
             },
             "funding": [
                 {
@@ -796,7 +796,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-17T10:55:18+00:00"
+            "time": "2024-05-31T14:57:53+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -867,16 +867,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v7.1.0",
+            "version": "v7.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "8ecdde25881598f86cdd7cfe8b25302b66a402e9"
+                "reference": "802e87002f919296c9f606457d9fa327a0b3d6b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/8ecdde25881598f86cdd7cfe8b25302b66a402e9",
-                "reference": "8ecdde25881598f86cdd7cfe8b25302b66a402e9",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/802e87002f919296c9f606457d9fa327a0b3d6b2",
+                "reference": "802e87002f919296c9f606457d9fa327a0b3d6b2",
                 "shasum": ""
             },
             "require": {
@@ -913,7 +913,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.1.0"
+                "source": "https://github.com/symfony/filesystem/tree/v7.1.1"
             },
             "funding": [
                 {
@@ -929,7 +929,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-17T10:55:18+00:00"
+            "time": "2024-05-31T14:57:53+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1334,16 +1334,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v7.1.0",
+            "version": "v7.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "6f41b185e742737917e6f2e3eca37767fba5f17a"
+                "reference": "60bc311c74e0af215101235aa6f471bcbc032df2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/6f41b185e742737917e6f2e3eca37767fba5f17a",
-                "reference": "6f41b185e742737917e6f2e3eca37767fba5f17a",
+                "url": "https://api.github.com/repos/symfony/string/zipball/60bc311c74e0af215101235aa6f471bcbc032df2",
+                "reference": "60bc311c74e0af215101235aa6f471bcbc032df2",
                 "shasum": ""
             },
             "require": {
@@ -1401,7 +1401,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.1.0"
+                "source": "https://github.com/symfony/string/tree/v7.1.1"
             },
             "funding": [
                 {
@@ -1417,7 +1417,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-17T10:55:18+00:00"
+            "time": "2024-06-04T06:40:14+00:00"
         }
     ],
     "packages-dev": [],

--- a/site/php-migrations/db/migrations/20240608141211_add_discord_verification_token_table.php
+++ b/site/php-migrations/db/migrations/20240608141211_add_discord_verification_token_table.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddDiscordVerificationTokenTable extends AbstractMigration
+{
+    public function up(): void
+    {
+        $table = $this->table('discord_verification_token', ['id' => false, 'primary_key' => ['token_id']]);
+        $table->addColumn('token_id', 'string', ['limit' => 41, 'null' => false])
+              ->addColumn('discord_id', 'string', ['limit' => 100])
+              ->addColumn('username', 'string', ['limit' => 100])
+              ->addColumn('verified_at', 'timestamp', ['null' => true])
+              ->addColumn('created_at', 'timestamp', ['default' => 'CURRENT_TIMESTAMP'])
+              ->create();
+
+    }
+}

--- a/site/web/api/verify-discord-id.php
+++ b/site/web/api/verify-discord-id.php
@@ -1,0 +1,46 @@
+<?php
+
+require_once(getenv('CONFIG_LIB_DIR') . '/config.php');
+require_once(getenv('CONFIG_LIB_DIR') . '/db.php');
+require_once(getenv('CONFIG_LIB_DIR') . '/session_auth.php');
+require_once(getenv('CONFIG_LIB_DIR') . '/template.php');
+require_once(getenv('CONFIG_LIB_DIR') . '/requests.php');
+
+render_header();
+
+$token = $_GET['token'];
+if (!$token) {
+  throw new Exception('Missing token parameter');
+}
+
+$badge_no = get_current_user_badge_no();
+$verification_result = db_set_discord_id_from_token($badge_no, $token);
+if ($verification_result["result"] === "no-token") {
+  throw new Exception('Invalid token');
+}
+
+if ($verification_result["result"] != "alread-verified") {
+  $message_resp = api_call('https://discord.com/api/channels/' . DISCORD_API_CHANNEL_ID . '/messages', [
+    'Authorization: Bot ' . DISCORD_BOT_TOKEN,
+    'Content-Type: application/json'
+  ], json_encode([
+    'content' => json_encode([
+      'action' => 'recheck-user',
+      'user-id' => $verification_result["id"]
+    ]),
+  ]));
+  if (!array_key_exists('id', $message_resp)) {
+    throw new Exception('Failed to send recheck message for ' . $verification_result["id"] . '\n' . print_r($message_resp, true));
+  }
+}
+
+?>
+  <a href="/" class="back">&lt; Back to member portal</a>
+  <article>
+    <h3>Success!</h3>
+    <p>Thank you, we have now associated this membership with the Discord account <?php echo $verification_result["username"]; ?>. You may close this tab.</p>
+  </article>
+<?php
+
+render_footer();
+?>

--- a/site/web/chat_callback.php
+++ b/site/web/chat_callback.php
@@ -61,7 +61,7 @@ if (!$discord_id || !$discord_username) {
 db_set_discord_id(get_current_user_badge_no(), $discord_id, $discord_username);
 
 // Create invite
-$invite_resp = api_call('https://discord.com/api/channels/' . DISCORD_CHANNEL_ID . '/invites', [
+$invite_resp = api_call('https://discord.com/api/channels/' . DISCORD_INVITE_CHANNEL_ID . '/invites', [
   'Authorization: Bot ' . DISCORD_BOT_TOKEN,
   'Content-Type: application/json'
 ], json_encode([


### PR DESCRIPTION
Add a new endpoint to allow users to link their discord identity with their membership.

The process of joining the discord through the portal has two discrete steps:
1) Get their discord account and associate it with their membership 2) Invite them to the discord

While 95% of the time both steps happen with the same discord account, certain circumstances mean step 1 and 2 can happen with different discord accounts. The most common scenario is they don't realise they have a discord account, so create a new one in step 1, and then in step 2 it loads the discord app logged into their old account.

This means we can have people joining the discord and we don't know which membership their discord account links to. To fill that gap, we now send a URL in the `/api/check-discord-ids` reponse instead of null. That url can be used to link the given discord account with the logged in membership. The Discord bot Watson then sends that link to them in a private thread.