### PR TITLE
Add "Skip log in" link

### DIFF
--- a/site/lib/auth_functions.php
+++ b/site/lib/auth_functions.php
@@ -10,15 +10,34 @@ function make_session($badge_no) {
     setcookie("session", $session_id, $expires_at, '/', '', true, true);
 }
 
+function make_anonymous_session() {
+  $expires_at = time() + 60*60*24;
+  setcookie('session', 'anonymous', $expires_at, '/', '', true, true);
+}
+
 function is_logged_in() {
   if (!isset($_COOKIE['session'])) {
+    return false;
+  }
+  if ($_COOKIE['session'] == 'anonymous') {
     return false;
   }
   return db_session_exists($_COOKIE['session']);
 }
 
-function get_current_user_badge_no() {
+function is_anonymous() {
   if (!isset($_COOKIE['session'])) {
+    return false;
+  }
+  return $_COOKIE['session'] == 'anonymous';
+}
+
+function make_login_link() {
+  return '/login?redirect=' . urlencode($_SERVER['REQUEST_URI']);
+}
+
+function get_current_user_badge_no() {
+  if (!isset($_COOKIE['session']) || $_COOKIE['session'] == 'anonymous') {
     return null;
   }
   return db_get_badge_no_by_session($_COOKIE['session']);
@@ -27,6 +46,9 @@ function get_current_user_badge_no() {
 function get_current_user_name() {
   if (!isset($_COOKIE['session'])) {
     return null;
+  }
+  if ($_COOKIE['session'] == 'anonymous') {
+    return 'Anonymous';
   }
   return db_get_user_name_by_session($_COOKIE['session']);
 }

--- a/site/lib/db.php
+++ b/site/lib/db.php
@@ -347,6 +347,21 @@ function db_delete_role($role_id) {
   $stmt->close();
 }
 
+function db_get_default_permissions() {
+  global $mysqli;
+
+  $stmt = $mysqli->prepare("SELECT permissions.name FROM permissions JOIN role_permissions USING (permission_id) JOIN roles USING (role_id) WHERE roles.name = 'default'");
+  $stmt->execute();
+  $stmt->bind_result($name);
+  $permissions = [];
+  while ($stmt->fetch()) {
+    $permissions[] = $name;
+  }
+  $stmt->close();
+
+  return $permissions;
+}
+
 function db_get_permissions_by_session($session_id) {
   global $mysqli;
 

--- a/site/lib/session_auth.php
+++ b/site/lib/session_auth.php
@@ -10,8 +10,14 @@ function check_permission($permission) {
 }
 
 if (!is_logged_in()) {
-  header('Location: /login?redirect=' . urlencode($_SERVER['REQUEST_URI']));
-  exit;
+  if (is_anonymous()) {
+    $_SESSION['username'] = 'Anonymous';
+    $_SESSION['permissions'] = db_get_default_permissions();
+    return;
+  } else {
+    header('Location: ' . make_login_link());
+    exit;
+  }
 }
 
 $_SESSION['username'] = get_current_user_name();

--- a/site/lib/template.php
+++ b/site/lib/template.php
@@ -36,11 +36,25 @@
 				  </div>
         </div>
         <?php
-          if (isset($_SESSION['username'])) {
+        if (isset($_SESSION['username'])) {
         ?>
-          <p class="username"><?php echo $_SESSION['username']; ?> | <a href="/logout">Logout</a></p>
+          <p class="username">
+            <?php echo $_SESSION['username']; ?>
+            |
+            <?php
+            if (is_anonymous()) {
+            ?>
+              <a href="<?php echo make_login_link(); ?>">Log in</a>
+            <?php
+            } else {
+            ?>
+              <a href="/logout">Log out</a>
+            <?php
+            }
+            ?>
+          </p>
         <?php
-          }
+        }
         ?>
       </div>
     </header>

--- a/site/web/chat.php
+++ b/site/web/chat.php
@@ -15,9 +15,16 @@ render_header();
   <p>We are using a platform called <a href="https://discord.com/" target="_blank">Discord</a> to host our online chat, both text and audio/video. There are apps for desktop and mobile, or you can use it in your browser.</p>
 <?php
   if (empty($usernames)) {
+    if (is_anonymous()) {
+?>
+      <p><a class="button" href="<?php echo make_login_link(); ?>">Log in to chat</a></p>
+<?php
+    } else {
+
 ?>
   <p><a class="button" target="_blank" href="https://discord.com/oauth2/authorize?client_id=<?php echo DISCORD_CLIENT_ID; ?>&response_type=code&redirect_uri=<?php echo urlencode(ROOT_URL) ?>%2Fchat_callback&scope=identify">Join the Discord server</a></p>
 <?php
+    }
   } else {
     if (count($usernames) === 1) {
 ?>

--- a/site/web/login.php
+++ b/site/web/login.php
@@ -14,6 +14,12 @@ session_start();
 
 $error = null;
 
+if (isset($_GET['skip-login'])) {
+    make_anonymous_session();
+    header('Location: ' . $_GET['redirect']);
+    exit();
+}
+
 if (isset($_GET['email']) && isset($_GET['login_code'])) {
     $email = $_GET['email'];
     $login_code = $_GET['login_code'];
@@ -45,9 +51,8 @@ if (isset($_GET['error_code'])) {
         'invalid-state' => 'An error occured while logging in with Glasgow Registration. Please try again.',
         'no-code' => 'Unable to log in with Glasgow Registration. Please try again and make sure you click the "Authorize" button after reviewing the permissions.',
         'no-access' => 'Your membership does not include access to the online convention. If you think this is a mistake, please e-mail <a href="mailto:registration@glasgow2024.org">registration@glasgow2024.org</a>.',
-        'under-age' => 'Your membership indicates you are under 16 and not allowed to access the online convention. If you think this is a mistake, please e-mail <a href="mailto:registration@glasgow2024.org">registration@glasgow2024.org</a>.',
+        'under-age' => 'Your membership indicates you are under 16 and not allowed to access the online convention. If you think this is a mistake, please e-mail <a href="mailto:registration@glasgow2024.org">registration@glasgow2024.org</a>.<p>You can still access most of the portal by clicking "Continue without logging in", but you will not be able to access any content that is age restricted such as watching streams or joining the Discord.</p>',
         'apocraphyl' => 'Your membership indcates that you are nt human! If you think this is a mistake, please e-mail <a href="mailto:registration@glasgow2024.org">registration@glasgow2024.org</a>.',
-        'duplicate-email' => 'An account with this e-mail address already exists. Please log in with your existing account.',
         'not-in-allowlist' => 'Sorry, the portal is not open for general access just yet. Watch for an email from the convention announcing it as open.',
     ][$_GET['error_code']] ?? 'An unknown error occured.';
 ?>
@@ -56,7 +61,8 @@ if (isset($_GET['error_code'])) {
 }
 ?>
     <p>If you are having trouble logging in, please e-mail <a href="mailto:<?php echo EMAIL; ?>?subject=Trouble logging in to member portal"><?php echo EMAIL; ?></a>.</p>
-    <a href="<?php echo $clyde->authorize_url(); ?>" class="button">Login with Glasgow Registration</a>
+    <a href="<?php echo $clyde->authorize_url(); ?>" class="button">Log in with Glasgow Registration</a>
+    <p><a href="/login?skip-login&redirect=<?php echo urlencode($_SESSION['oauth2redirect']); ?>">Continue without logging in</a></p>
 </article>
 
 <?php

--- a/site/web/stream.php
+++ b/site/web/stream.php
@@ -4,10 +4,8 @@ require_once(getenv('CONFIG_LIB_DIR') . '/session_auth.php');
 require_once(getenv('CONFIG_LIB_DIR') . '/template.php');
 
 if (array_key_exists('invite', $_GET)) {
-  if (!current_user_has_permission('see-rce')) {
-    header('Location: /');
-    exit;
-  }
+  check_permission('see-rce-link');
+
   $magic_link = db_get_magic_link($_COOKIE['session']);
   header('Location: ' . $magic_link);
   setcookie('seen-rce-invite', '1', time() + 60*60*24*365, '/');
@@ -22,9 +20,13 @@ render_header();
 <article>
   <h3>Stream and catch-up</h3>
   <p>We are using a platform called RingCentral Events to stream our programme items. You can watch the live streams of programme items, or watch the recorded videos afterwards. It works on both desktop and mobile.</p>
-  <p>Items will be available for catch-up until 1<sup>st</sup> May 2024.</p>
+  <p>Items will be available for catch-up until the end of 2024.</p>
 <?php
-  if (!current_user_has_permission('see-rce')) {
+  if (is_anonymous()) {
+?>
+  <p><a class="button" href="<?php echo make_login_link(); ?>">Log in to watch</a></p>
+<?php
+  } else if (!current_user_has_permission('see-rce-link')) {
 ?>
   <p>Our RingCentral Event will open Friday morning. Please check back then.</p>
 <?php
@@ -34,7 +36,6 @@ render_header();
 <?php
   }
 ?>
-  <p>The use of RingCentral Events is thanks to the generosity of <a href="https://glasgow2024.org/">Glasgow 2024</a>. This is the same platform as will be used at this year's Worldcon, Glasgow 2024.</p>
   <h4>How to use RingCentral Events</h4>
   <p>In the <a href="https://eastercon2024.co.uk/guide-to-ringcentral-events/">our guide</a> you will find instructions on how to:</p>
   <ul>


### PR DESCRIPTION
Add the option to skip the log in. This will allow people who can't or don't want to log in (e.g. people under 16) to still have access to the useful links in the portal.

Places that require authentication, such as the RCE or Discord links, still require you to log in.