### PR TITLE
Add API_KEYS to config

### DIFF
--- a/site/lib/config.php
+++ b/site/lib/config.php
@@ -18,6 +18,7 @@ define('RCE_TICKET_ID', $config_file['rce']['ticket_id']);
 define('DISCORD_BOT_TOKEN', $config_file['discord']['bot_token']);
 define('DISCORD_CLIENT_ID', $config_file['discord']['client_id']);
 define('DISCORD_CLIENT_SECRET', $config_file['discord']['client_secret']);
+define('API_KEYS', $config_file['api_keys']);
 
 define('CLYDE_CLIENT_ID', $config_file['clyde']['client_id']);
 define('CLYDE_CLIENT_SECRET', $config_file['clyde']['client_secret']);


### PR DESCRIPTION
Add API_KEYS to config for use by the Discord API. This was just something that got missed in the initial conversion of how config is configured in the new dockerized world.

This new config has a slight tweak. Before we would allow multiple keys to be configured for the same client name to allow rotation. For simplicity, we have gotten rid of that. You can just use a new client name for the new key.