### PR TITLE
Add /api/verify-discord-id to let members link discord ids

### DIFF
--- a/site/lib/config.php
+++ b/site/lib/config.php
@@ -3,7 +3,8 @@
 define('ROOT_URL', 'https://' . $_SERVER['HTTP_X_FORWARDED_HOST'] ?? _SERVER['HTTP_HOST']);
 define('CON_NAME', 'Glasgow 2024, a Worldcon for Our Futures');
 define('CON_SHORT_NAME', 'Glasgow 2024');
-define('DISCORD_CHANNEL_ID', '1214240728184787013');
+define('DISCORD_INVITE_CHANNEL_ID', '1214240728184787013');
+define('DISCORD_API_CHANNEL_ID', '1248917066807775232');
 define("EMAIL", "info@eastercon2024.co.uk");
 define('TIMEZONE', 'Europe/London');
 

--- a/site/php-migrations/db/migrations/20240608141211_add_discord_verification_token_table.php
+++ b/site/php-migrations/db/migrations/20240608141211_add_discord_verification_token_table.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddDiscordVerificationTokenTable extends AbstractMigration
+{
+    public function up(): void
+    {
+        $table = $this->table('discord_verification_token', ['id' => false, 'primary_key' => ['token_id']]);
+        $table->addColumn('token_id', 'string', ['limit' => 41, 'null' => false])
+              ->addColumn('discord_id', 'string', ['limit' => 100])
+              ->addColumn('username', 'string', ['limit' => 100])
+              ->addColumn('verified_at', 'timestamp', ['null' => true])
+              ->addColumn('created_at', 'timestamp', ['default' => 'CURRENT_TIMESTAMP'])
+              ->create();
+
+    }
+}

--- a/site/web/api/check-discord-ids.php
+++ b/site/web/api/check-discord-ids.php
@@ -84,11 +84,16 @@ try {
   $recorded_discord_info = db_get_all_discord_info();
   $response = [];
 
-  foreach ($data["discordUserIds"] as $discord_id) {
+  foreach ($data["discordUsers"] as $discord_user) {
+    $discord_id = $discord_user["id"];
+    $discord_username = $discord_user["username"];
     if (isset($recorded_discord_info[$discord_id])) {
       $response[$discord_id] = $recorded_discord_info[$discord_id];
     } else {
-      $response[$discord_id] = null;
+      $token = base64_encode(random_bytes(30));
+      db_insert_discord_token($token, $discord_id, $discord_username);
+      $url = ROOT_URL . "/api/verify-discord-id?token=" . urlencode($token);
+      $response[$discord_id] = $url;
     }
   }
 

--- a/site/web/api/verify-discord-id.php
+++ b/site/web/api/verify-discord-id.php
@@ -1,0 +1,46 @@
+<?php
+
+require_once(getenv('CONFIG_LIB_DIR') . '/config.php');
+require_once(getenv('CONFIG_LIB_DIR') . '/db.php');
+require_once(getenv('CONFIG_LIB_DIR') . '/session_auth.php');
+require_once(getenv('CONFIG_LIB_DIR') . '/template.php');
+require_once(getenv('CONFIG_LIB_DIR') . '/requests.php');
+
+render_header();
+
+$token = $_GET['token'];
+if (!$token) {
+  throw new Exception('Missing token parameter');
+}
+
+$badge_no = get_current_user_badge_no();
+$verification_result = db_set_discord_id_from_token($badge_no, $token);
+if ($verification_result["result"] === "no-token") {
+  throw new Exception('Invalid token');
+}
+
+if ($verification_result["result"] != "alread-verified") {
+  $message_resp = api_call('https://discord.com/api/channels/' . DISCORD_API_CHANNEL_ID . '/messages', [
+    'Authorization: Bot ' . DISCORD_BOT_TOKEN,
+    'Content-Type: application/json'
+  ], json_encode([
+    'content' => json_encode([
+      'action' => 'recheck-user',
+      'user-id' => $verification_result["id"]
+    ]),
+  ]));
+  if (!array_key_exists('id', $message_resp)) {
+    throw new Exception('Failed to send recheck message for ' . $verification_result["id"] . '\n' . print_r($message_resp, true));
+  }
+}
+
+?>
+  <a href="/" class="back">&lt; Back to member portal</a>
+  <article>
+    <h3>Success!</h3>
+    <p>Thank you, we have now associated this membership with the Discord account <?php echo $verification_result["username"]; ?>. You may close this tab.</p>
+  </article>
+<?php
+
+render_footer();
+?>

--- a/site/web/chat_callback.php
+++ b/site/web/chat_callback.php
@@ -61,7 +61,7 @@ if (!$discord_id || !$discord_username) {
 db_set_discord_id(get_current_user_badge_no(), $discord_id, $discord_username);
 
 // Create invite
-$invite_resp = api_call('https://discord.com/api/channels/' . DISCORD_CHANNEL_ID . '/invites', [
+$invite_resp = api_call('https://discord.com/api/channels/' . DISCORD_INVITE_CHANNEL_ID . '/invites', [
   'Authorization: Bot ' . DISCORD_BOT_TOKEN,
   'Content-Type: application/json'
 ], json_encode([


### PR DESCRIPTION
Add a new endpoint to allow users to link their discord identity with their membership.

The process of joining the discord through the portal has two discrete steps:

1. Get their discord account and associate it with their membership
2. Invite them to the discord

While 95% of the time both steps happen with the same discord account, certain circumstances mean step 1 and 2 can happen with different discord accounts. The most common scenario is they don't realise they have a discord account, so create a new one in step 1, and then in step 2 it loads the discord app logged into their old account.

This means we can have people joining the discord and we don't know which membership their discord account links to. To fill that gap, we now send a URL in the /api/check-discord-ids reponse instead of null. That url can be used to link the given discord account with the logged in membership. The Discord bot Watson then sends that link to them in a private thread.