### PR TITLE
Use badge_no for login links

### DIFF
--- a/site/lib/auth_functions.php
+++ b/site/lib/auth_functions.php
@@ -104,8 +104,8 @@ function create_member($badge_no, $email, $name) {
   db_create_member($badge_no, $name, $email, $magic_link);
 }
 
-function get_login_link_status($email, $login_code) {
-  $expires = db_get_login_link_expiry($email, $login_code);
+function get_login_link_status($badge_no, $login_code) {
+  $expires = db_get_login_link_expiry($badge_no, $login_code);
   if ($expires == null) {
     return "no-found";
   }

--- a/site/lib/db.php
+++ b/site/lib/db.php
@@ -188,11 +188,11 @@ function db_insert_login_link($email, $login_code, $expires_at) {
   $stmt->close();
 }
 
-function db_get_login_link_expiry($email, $login_code) {
+function db_get_login_link_expiry($badge_no, $login_code) {
   global $mysqli;
 
-  $stmt = $mysqli->prepare("SELECT expires_at FROM login_links WHERE login_code = ? AND badge_no = (SELECT badge_no FROM members WHERE email = ?)");
-  $stmt->bind_param("ss", $login_code, $email);
+  $stmt = $mysqli->prepare("SELECT expires_at FROM login_links WHERE login_code = ? AND badge_no = ?");
+  $stmt->bind_param("ss", $login_code, $badge_no);
   $stmt->execute();
   $stmt->bind_result($expires_at);
   if (!$stmt->fetch()) {
@@ -307,7 +307,7 @@ function db_get_role_permissions($role_id) {
     $permissions[] = ['permission_id' => $permission_id, 'name' => $name, 'has_permission' => $has_permission];
   }
   $stmt->close();
-  
+
   return $permissions;
 }
 

--- a/site/web/login.php
+++ b/site/web/login.php
@@ -18,13 +18,13 @@ if (isset($_GET['skip-login'])) {
     exit();
 }
 
-if (isset($_GET['email']) && isset($_GET['login_code'])) {
-    $email = $_GET['email'];
+if (isset($_GET['badge_no']) && isset($_GET['login_code'])) {
+    $badge_no = $_GET['badge_no'];
     $login_code = $_GET['login_code'];
 
-    $link_status = get_login_link_status($email, $login_code);
+    $link_status = get_login_link_status($badge_no, $login_code);
     if ($link_status === "ok") {
-        make_session($email);
+        make_session($badge_no);
         header('Location: /');
         exit();
     } else if ($link_status === "expired") {


### PR DESCRIPTION
Emails are no longer unique with the Clyde login setup. Instead use badge_no for the login links.