### PR TITLE
Don't run composer update on start.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Requirements:
 5. Go to [http://localhost:8080] for the portal, and [http://localhost:8081] for
    phpMyAdmin.
 
+### Updating dependencies
+1. Add the dependency to `site/lib/composer.json`
+2. Run `docker exec web bash -c 'cd /srv/lib; composer update'`
+
 ### Database changes
 1. All migrations use phinx for database changes. The migrations are in the folder
    `sites/php-migrations`

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -12,12 +12,12 @@ done
 
 # Setup and install vendor libs
 cd /srv/lib
-composer update
+composer install
 
 # Setup and run migrations
 cd /var/php-migrations
 # ensure phinx etc is installed
-composer update
+composer install
 
 # run the migrations
 # NOTE: RUNTIME_ENV is set to developmen or production ...


### PR DESCRIPTION
Use `install` not `update` in `start.sh`. By using install, we were updating the dependencies every time we restarted the container. This makes for a moving target where the dependencies we're testing with locally might not necessarily match what get installed when we deploy.