### PR TITLE
Add assign-discord-posts API

### DIFF
--- a/site/lib/api.php
+++ b/site/lib/api.php
@@ -1,0 +1,100 @@
+<?php
+
+require_once(getenv('CONFIG_LIB_DIR') . '/config.php');
+require_once(getenv('CONFIG_LIB_DIR') . '/db.php');
+
+class ClientException extends Exception {
+  public $public_error_code;
+
+  public function __construct($public_error_code, $message, $code = 0, Throwable $previous = null) {
+      $this->public_error_code = $public_error_code;
+      parent::__construct($message, $code, $previous);
+  }
+}
+
+class AuthorizationException extends Exception { }
+
+function validate_signature() {
+  $headers = array_change_key_case(apache_request_headers(), CASE_LOWER);
+  if (!isset($headers["authorization"])) {
+    throw new AuthorizationException("Missing required Authorization header");
+  }
+  $auth_header = $headers["authorization"];
+  $auth_header_parts = explode(" ", $auth_header, 3);
+
+  if ($auth_header_parts[0] != "members:1") {
+    throw new AuthorizationException("Invalid authorization header");
+  }
+
+  if (!isset($headers["x-members-requesttime"])) {
+    throw new AuthorizationException("Missing required X-Members-RequestTime header");
+  }
+
+  $client_name = $auth_header_parts[1];
+  if (!isset(API_KEYS[$client_name])) {
+    throw new AuthorizationException("Unknown client name");
+  }
+
+  $request_time_str = $headers["x-members-requesttime"];
+  $request_time = DateTimeImmutable::createFromFormat("Y-m-d\TH:i:s\Z", $request_time_str);
+  if (!$request_time) {
+    throw new AuthorizationException("Malformed X-Members-RequestTime header");
+  }
+  $tolerance = new DateInterval("PT5M");
+  $lower_bound = $request_time->sub($tolerance);
+  $upper_bound = $request_time->add($tolerance);
+  $now = new DateTimeImmutable("NOW");
+  // We don't want clients weakening the security by trying to make requests with a timestamp far in the future.
+  if ($now < $lower_bound || $now > $upper_bound) {
+    throw new AuthorizationException("Request authorization has timed out");
+  }
+
+  $webhook_data = strtoupper($_SERVER["REQUEST_METHOD"]) . "\n" . $_SERVER["REQUEST_URI"] . "\n" . $request_time_str . "\n" . base64_encode(file_get_contents("php://input"));
+  $webhook_sig = hash_hmac("sha256", $webhook_data, API_KEYS[$client_name]);
+  if ($webhook_sig != $auth_header_parts[2]) {
+    throw new AuthorizationException("Invalid signature");
+  }
+}
+
+function send_error($http_status, $code, $error, $instance=null) {
+  http_response_code($http_status);
+  header("Content-Type: application/json; charset=utf-8");
+  $resp = array(
+      "code" => $code,
+      "error" => $error
+  );
+  if (!is_null($instance)) {
+      $resp["instance"] = $instance;
+  }
+  echo json_encode($resp);
+}
+
+function handle_request($handler) {
+  try {
+    validate_signature();
+  
+    if ($_SERVER["CONTENT_TYPE"] != "application/json") {
+      throw new ClientException("ERR_MALFORMED_BODY", "Content-Type must be 'application/json'");
+    }
+    $json = file_get_contents('php://input');
+    $data = json_decode($json, true);
+    if (!$data) {
+        throw new ClientException("ERR_MALFORMED_BODY", "Error parsing content as json");
+    }
+    
+    $response = $handler($data);
+  
+    http_response_code(200);
+    header("Content-Type: application/json; charset=utf-8");
+    echo json_encode($response);
+  } catch (ClientException $e) {
+    send_error(400, $e->public_error_code, $e->getMessage());
+  } catch (AuthorizationException $e) {
+    // Log auth errors in case we need to spot people brute forcing
+    $instance = log_exception($e);
+    send_error(401, "ERR_AUTH", $e->getMessage(), $instance);
+  } catch (Exception $e) {
+    $instance = log_exception($e);
+    send_error(500, "ERR_INTERNAL", "An internal error occurred", $instance);
+  }  
+}

--- a/site/lib/db.php
+++ b/site/lib/db.php
@@ -602,6 +602,28 @@ function db_add_discord_post($item_id, $start, $duration, $room_id, $post_url) {
   return $mysqli->insert_id;
 }
 
+function db_upsert_discord_post($item_id, $start, $duration, $room_id, $post_url) {
+  global $mysqli;
+
+  if ($start) {
+    $date = new DateTime($start, new DateTimeZone(TIMEZONE));
+    $start_time = $date->getTimestamp();
+  } else {
+    $start_time = null;
+  }
+
+  if ($duration) {
+    $duration_secs = intval($duration) * 60;
+  } else {
+    $duration_secs = null;
+  }
+
+  $stmt = $mysqli->prepare("INSERT INTO prog_discord_posts (item_id, start, duration, room_id, post_url) VALUES (?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE start = VALUES(start), duration = VALUES(duration), room_id = VALUES(room_id), post_url = VALUES(post_url)");
+  $stmt->bind_param("siiss", $item_id, $start_time, $duration_secs, $room_id, $post_url);
+  $stmt->execute();
+  $stmt->close();
+}
+
 function db_delete_discord_post($item_id) {
   global $mysqli;
 

--- a/site/web/api/assign-discord-posts.php
+++ b/site/web/api/assign-discord-posts.php
@@ -1,0 +1,10 @@
+<?php
+
+require_once(getenv('CONFIG_LIB_DIR') . '/api.php');
+
+handle_request(function($data) {
+  foreach ($data as $post) {
+    db_upsert_discord_post($post['itemId'], $post['start'], $post['mins'], $post['roomId'], $post['postUrl']);
+  }
+  return ['result' => 'success'];
+});

--- a/site/web/api/check-discord-ids.php
+++ b/site/web/api/check-discord-ids.php
@@ -1,86 +1,8 @@
 <?php
 
-require_once(getenv('CONFIG_LIB_DIR') . '/config.php');
-require_once(getenv('CONFIG_LIB_DIR') . '/db.php');
+require_once(getenv('CONFIG_LIB_DIR') . '/api.php');
 
-class ClientException extends Exception {
-  public $public_error_code;
-
-  public function __construct($public_error_code, $message, $code = 0, Throwable $previous = null) {
-      $this->public_error_code = $public_error_code;
-      parent::__construct($message, $code, $previous);
-  }
-}
-
-class AuthorizationException extends Exception { }
-
-function validate_signature() {
-  $headers = array_change_key_case(apache_request_headers(), CASE_LOWER);
-  if (!isset($headers["authorization"])) {
-    throw new AuthorizationException("Missing required Authorization header");
-  }
-  $auth_header = $headers["authorization"];
-  $auth_header_parts = explode(" ", $auth_header, 3);
-
-  if ($auth_header_parts[0] != "members:1") {
-    throw new AuthorizationException("Invalid authorization header");
-  }
-
-  if (!isset($headers["x-members-requesttime"])) {
-    throw new AuthorizationException("Missing required X-Members-RequestTime header");
-  }
-
-  $client_name = $auth_header_parts[1];
-  if (!isset(API_KEYS[$client_name])) {
-    throw new AuthorizationException("Unknown client name");
-  }
-
-  $request_time_str = $headers["x-members-requesttime"];
-  $request_time = DateTimeImmutable::createFromFormat("Y-m-d\TH:i:s\Z", $request_time_str);
-  if (!$request_time) {
-    throw new AuthorizationException("Malformed X-Members-RequestTime header");
-  }
-  $tolerance = new DateInterval("PT5M");
-  $lower_bound = $request_time->sub($tolerance);
-  $upper_bound = $request_time->add($tolerance);
-  $now = new DateTimeImmutable("NOW");
-  // We don't want clients weakening the security by trying to make requests with a timestamp far in the future.
-  if ($now < $lower_bound || $now > $upper_bound) {
-    throw new AuthorizationException("Request authorization has timed out");
-  }
-
-  $webhook_data = strtoupper($_SERVER["REQUEST_METHOD"]) . "\n" . $_SERVER["REQUEST_URI"] . "\n" . $request_time_str . "\n" . base64_encode(file_get_contents("php://input"));
-  $webhook_sig = hash_hmac("sha256", $webhook_data, API_KEYS[$client_name]);
-  if ($webhook_sig != $auth_header_parts[2]) {
-    throw new AuthorizationException("Invalid signature");
-  }
-}
-
-function send_error($http_status, $code, $error, $instance=null) {
-  http_response_code($http_status);
-  header("Content-Type: application/json; charset=utf-8");
-  $resp = array(
-      "code" => $code,
-      "error" => $error
-  );
-  if (!is_null($instance)) {
-      $resp["instance"] = $instance;
-  }
-  echo json_encode($resp);
-}
-
-try {
-  validate_signature();
-
-  if ($_SERVER["CONTENT_TYPE"] != "application/json") {
-    throw new ClientException("ERR_MALFORMED_BODY", "Content-Type must be 'application/json'");
-  }
-  $json = file_get_contents('php://input');
-  $data = json_decode($json, true);
-  if (!$data) {
-      throw new ClientException("ERR_MALFORMED_BODY", "Error parsing content as json");
-  }
-
+handle_request(function($data) {
   $recorded_discord_info = db_get_all_discord_info();
   $response = [];
 
@@ -97,17 +19,7 @@ try {
     }
   }
 
-  http_response_code(200);
-  header("Content-Type: application/json; charset=utf-8");
-  echo json_encode($response);
-} catch (ClientException $e) {
-  send_error(400, $e->public_error_code, $e->getMessage());
-} catch (AuthorizationException $e) {
-  // Log auth errors in case we need to spot people brute forcing
-  $instance = log_exception($e);
-  send_error(401, "ERR_AUTH", $e->getMessage(), $instance);
-} catch (Exception $e) {
-  $instance = log_exception($e);
-  send_error(500, "ERR_INTERNAL", "An internal error occurred", $instance);
-}
+  return $response;
+});
+
 ?>


### PR DESCRIPTION
Add API to allow Watson to tell us the URL for discord posts for use in the deep links.

This required extracting the API handling code so it can be shared between the two.