### PR TITLE
Increase length of URL columns

### DIFF
--- a/site/php-migrations/db/migrations/20240625181718_increase_url_lengths.php
+++ b/site/php-migrations/db/migrations/20240625181718_increase_url_lengths.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class IncreaseUrlLengths extends AbstractMigration
+{
+    public function up(): void
+    {
+        $this->table('prog_discord_posts')
+            ->changeColumn('post_url', 'string', ['limit' => 2048])
+            ->update();
+        $this->table('prog_replay')
+            ->changeColumn('replay_url', 'string', ['limit' => 2048])
+            ->update();
+        $this->table('prog_sessions')
+            ->changeColumn('rce_url', 'string', ['limit' => 2048])
+            ->update();
+        $this->table('prog_stages')
+            ->changeColumn('viewer_url', 'string', ['limit' => 2048])
+            ->changeColumn('participant_url', 'string', ['limit' => 2048])
+            ->update();
+        $this->table('prog_zoom')
+            ->changeColumn('zoom_url', 'string', ['limit' => 512, 'null' => false])
+            ->update();
+    }
+}


### PR DESCRIPTION
The RCE URLs are long! Okay, maybe not 2048 long, but we're not especially starved of space, so go with the limit on length that Chrome uses.