### PR TITLE
Link to a temporary conclar instance for demo purposes

### DIFF
--- a/site/web/index.php
+++ b/site/web/index.php
@@ -24,7 +24,7 @@ $cards = [
     'title' => 'Programme guide',
     'subtitle' => 'ConClár',
     'description' => 'See what\'s on where and when. Bookmark items to make sure you don\'t miss them.',
-    'link' => '/under-construction?page=Programme+guide',
+    'link' => 'https://ajanuary.com/static/glasgow2024-conclar/',
     'card-permission' => 'see-guide',
   ], [
     'name' => 'maps',


### PR DESCRIPTION
For a demo to the DH we need conclar set up. But we don't have the proper one available yet. Instead, link to the temporary one set up on ajanuary.com.