### PR TITLE
Change assign-discord-post to take time in UTC

### DIFF
--- a/site/lib/db.php
+++ b/site/lib/db.php
@@ -614,7 +614,7 @@ function db_upsert_discord_post($item_id, $title, $start, $duration, $room_id, $
   global $mysqli;
 
   if ($start) {
-    $date = new DateTime($start, new DateTimeZone(TIMEZONE));
+    $date = new DateTime($start, new DateTimeZone("UTC"));
     $start_time = $date->getTimestamp();
   } else {
     $start_time = null;


### PR DESCRIPTION
Plano sends the time to Watson in UTC, so accept UTC in the assign-discord-post.