### PR TITLE
Join the server as well as sending an invite

### DIFF
--- a/site/lib/config.php
+++ b/site/lib/config.php
@@ -3,7 +3,8 @@
 define('ROOT_URL', 'https://' . $_SERVER['HTTP_X_FORWARDED_HOST'] ?? _SERVER['HTTP_HOST']);
 define('CON_NAME', 'Glasgow 2024, a Worldcon for Our Futures');
 define('CON_SHORT_NAME', 'Glasgow 2024');
-define('DISCORD_INVITE_CHANNEL_ID', '1229126647954018457');
+define('DISCORD_GUILD_ID', '1229093507835101204');
+define('DISCORD_INVITE_CHANNEL_ID', '1229126688277926008');
 define('DISCORD_API_CHANNEL_ID', '1248917066807775232');
 define("SUPPORT_EMAIL", "online-support@glasgow2024.org");
 define('TIMEZONE', 'Europe/London');

--- a/site/lib/requests.php
+++ b/site/lib/requests.php
@@ -1,10 +1,14 @@
 <?php
 
-function api_call($url, $headers, $payload=false) {
+function api_call($url, $headers, $payload=false, $method=null) {
   $ch = curl_init($url);
   curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
   if ($payload) {
-    curl_setopt($ch, CURLOPT_POST, 1);
+    if ($method) {
+      curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
+    } else {
+      curl_setopt($ch, CURLOPT_POST, 1);
+    }
     curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
   }
   curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/site/web/chat.php
+++ b/site/web/chat.php
@@ -25,7 +25,7 @@ render_header(
     } else {
 
 ?>
-  <p><a class="button" target="_blank" href="https://discord.com/oauth2/authorize?client_id=<?php echo DISCORD_CLIENT_ID; ?>&response_type=code&redirect_uri=<?php echo urlencode(ROOT_URL) ?>%2Fchat_callback&scope=identify">Join the Discord server</a></p>
+  <p><a class="button" target="_blank" href="https://discord.com/oauth2/authorize?client_id=<?php echo DISCORD_CLIENT_ID; ?>&response_type=code&redirect_uri=<?php echo urlencode(ROOT_URL) ?>%2Fchat_callback&scope=identify+guilds.join">Join the Discord server</a></p>
 <?php
     }
   } else {
@@ -49,7 +49,7 @@ render_header(
     }
 ?>
   <p><a class="button" target="_blank" href="https://discord.com/channels/1214240728130256926/1214240728583118871">Go to Discord in your browser</a> or log in as <?php echo $usernames[0]; ?> in the <a href="https://discord.com/download">Discord app</a></p>
-  <p><a target="_blank" href="https://discord.com/oauth2/authorize?client_id=<?php echo DISCORD_CLIENT_ID; ?>&response_type=code&redirect_uri=<?php echo urlencode(ROOT_URL) ?>%2Fchat_callback&scope=identify">Join the Discord server as a different user</a></p>
+  <p><a target="_blank" href="https://discord.com/oauth2/authorize?client_id=<?php echo DISCORD_CLIENT_ID; ?>&response_type=code&redirect_uri=<?php echo urlencode(ROOT_URL) ?>%2Fchat_callback&scope=identify+guilds.join">Join the Discord server as a different user</a></p>
 <?php
   }
 ?>

--- a/site/web/deep-link/chat.php
+++ b/site/web/deep-link/chat.php
@@ -59,7 +59,7 @@ if (!empty($usernames)) {
   exit;
 }
 
-$invite_url = 'https://discord.com/oauth2/authorize?client_id=' . DISCORD_CLIENT_ID . '&response_type=code&redirect_uri=' . urlencode(ROOT_URL) . '%2Fchat_callback&scope=identify';
+$invite_url = 'https://discord.com/oauth2/authorize?client_id=' . DISCORD_CLIENT_ID . '&response_type=code&redirect_uri=' . urlencode(ROOT_URL) . '%2Fchat_callback&scope=identify+guilds.join';
 
 render_header(
   'Go to a Discord chat for an item',


### PR DESCRIPTION
We've found issues with people accepting the invite. To try and work around that, join the server for them. We still send an invite for two reasons:
1) We want it to load the discord UI to get them straight into it 2) If they are using a different account in their app vs what they
   logged in with, we still want them invited (and the link auth flow
   will be used instead)